### PR TITLE
Added flags for multiline description

### DIFF
--- a/docstring_parser/rest.py
+++ b/docstring_parser/rest.py
@@ -38,7 +38,7 @@ def _build_meta(args: T.List[str], desc: str) -> DocstringMeta:
                 f"Expected one or two arguments for a {key} keyword."
             )
 
-        m = re.match(r".*defaults to (.+)", desc)
+        m = re.match(r".*defaults to (.+)", desc, flags=re.DOTALL)
         default = m.group(1).rstrip(".") if m else None
 
         return DocstringParam(


### PR DESCRIPTION
Add flags=re.DOTALL to the regular expresion match used to find "defaults to" so it can manage multiline description.